### PR TITLE
don't open devTools at start

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,8 +15,6 @@ function createWindow () {
     slashes: true
   }))
 
-  mainWindow.webContents.openDevTools()
-
   mainWindow.on('closed', function () {
     mainWindow = null
   })


### PR DESCRIPTION
hey @sethvincent, i tested this on Debian Jessie Linux and it works! :sparkles:

but when i started the app, the devTools immediately opened and covered most of the app, so this pull request removes that behavior. you might want to instead wrap it in a `if (process.env.NODE_ENV === 'development') { ...`, but i'll leave that to you.